### PR TITLE
End call from outside activity

### DIFF
--- a/qiscus-rtc/src/main/java/com/qiscus/rtc/QiscusRTC.java
+++ b/qiscus-rtc/src/main/java/com/qiscus/rtc/QiscusRTC.java
@@ -12,6 +12,7 @@ import com.qiscus.rtc.data.local.LocalDataManager;
 import com.qiscus.rtc.data.model.QiscusRTCAccount;
 import com.qiscus.rtc.data.model.QiscusRTCCall;
 import com.qiscus.rtc.data.model.QiscusRTCSession;
+import com.qiscus.rtc.engine.util.QiscusRTCListener;
 import com.qiscus.rtc.ui.call.activity.QiscusCallActivity;
 
 import org.json.JSONException;
@@ -365,6 +366,7 @@ public class QiscusRTC {
         private CallType callType = CallType.VOICE;
         private boolean accepted = false;
         private boolean connected = false;
+        private QiscusRTCListener rtcListener;
 
         /**
          * Get QiscusRTC call instance.
@@ -472,6 +474,24 @@ public class QiscusRTC {
             }
 
             return callConfig;
+        }
+
+        /**
+         * Set call listener
+         *
+         * @param rtcListener call activity
+         */
+        public void setRtcListener(QiscusRTCListener rtcListener) {
+            this.rtcListener = rtcListener;
+        }
+
+        /**
+         * End current call
+         */
+        public void endCall() {
+            if (rtcListener != null) {
+                rtcListener.onCallEnded();
+            }
         }
     }
 

--- a/qiscus-rtc/src/main/java/com/qiscus/rtc/ui/call/activity/QiscusCallActivity.java
+++ b/qiscus-rtc/src/main/java/com/qiscus/rtc/ui/call/activity/QiscusCallActivity.java
@@ -91,6 +91,8 @@ public class QiscusCallActivity extends BaseActivity implements CallingFragment.
             }
 
             callEventData = new QiscusRTC.CallEventData();
+
+            QiscusRTC.Call.getInstance().setRtcListener(this);
         } else {
             finish();
         }
@@ -135,6 +137,7 @@ public class QiscusCallActivity extends BaseActivity implements CallingFragment.
     protected void onDestroy() {
         Thread.setDefaultUncaughtExceptionHandler(null);
         NotificationManagerCompat.from(this).cancel(ON_GOING_NOTIF_ID);
+        QiscusRTC.Call.getInstance().setRtcListener(null);
         disconnect();
         super.onDestroy();
     }


### PR DESCRIPTION
Add function to end call from outside QiscusCallActivity. In ummaline we need to end call after mentoring session has ended, so we need to notify QiscusCallActivity to stop the call.

How to use:
```QiscusRTC.Call.getInstance().endCall();```